### PR TITLE
The version '2.0' of mongoid gem has a nasty bug, bump to ~> 2.3

### DIFF
--- a/mongoid_session_store.gemspec
+++ b/mongoid_session_store.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "mongoid_session_store"
-  s.version = "2.0.1"
+  s.version = "2.0.2"
   s.authors     = ["Ryan Fitzgerald", "Code Brew Studios"]
   s.email       = ["ryan@codebrewstudios.com"]
   s.homepage    = "http://github.com/codebrew/mongoid_session_store"
@@ -9,5 +9,5 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*"] + ["MIT-LICENSE", "Rakefile", "README.rdoc"]
   
   s.add_dependency('rails', "~> 3.0")
-  s.add_dependency('mongoid', '~> 2.0')
+  s.add_dependency('mongoid', '~> 2.3')
 end


### PR DESCRIPTION
The exact version '2.0.x' of mongoid that's available has a nasty bug with newer bundle/rubygems:

```
sudo gem install mongoid_session_store
ERROR:  While executing gem ... (NameError)
    uninitialized constant Syck::Syck
```

2.3+ is fixed. Took the liberty to bump a minor version ;)
